### PR TITLE
Remove the panGesture's requirement that the tapGesture fails.

### DIFF
--- a/lib/NVSlideMenuController/NVSlideMenuController.m
+++ b/lib/NVSlideMenuController/NVSlideMenuController.m
@@ -570,7 +570,6 @@
 	if (!_panGesture)
 	{
 		_panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGestureTriggered:)];
-		[_panGesture requireGestureRecognizerToFail:self.tapGesture];
 	}
 	
 	return _panGesture;


### PR DESCRIPTION
This makes the pan gesture more responsive when closing the menu. In the current state, if the menu is open there is a delay when dragging the content view to close it. This was caused by waiting for the tap gesture to fail before beginning the pan.

With this change the content view will now respond immediately when the user drags it while the menu is open. In my testing I haven't found any negative side effects, the tap gesture still works correctly and it greatly improves the perceived responsiveness of the pan gesture.
