### PR TITLE
Make panGesture a public property

### DIFF
--- a/lib/NVSlideMenuController/NVSlideMenuController.h
+++ b/lib/NVSlideMenuController/NVSlideMenuController.h
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSUInteger, NVSlideMenuControllerSlideDirection)
 - (BOOL)isContentViewHidden;
 
 /** @name Gestures */
-@property (nonatomic, strong) UIPanGestureRecognizer *panGesture;
+@property (nonatomic, strong, readonly) UIPanGestureRecognizer *panGesture;
 
 @end
 

--- a/lib/NVSlideMenuController/NVSlideMenuController.m
+++ b/lib/NVSlideMenuController/NVSlideMenuController.m
@@ -45,6 +45,7 @@
 
 @property (nonatomic, assign) CGRect contentViewControllerFrame;
 @property (nonatomic, assign) BOOL menuWasOpenAtPanBegin;
+@property (nonatomic, strong, readwrite) UIPanGestureRecognizer *panGesture;
 - (void)panGestureTriggered:(UIPanGestureRecognizer *)panGesture;
 
 /** Utils */


### PR DESCRIPTION
It would be nice if `panGesture` were a public property. Doing so would allow library users to implement a delegate or add targets to the gesture in order to better control it. For example, it's nice to be able to restrict the area that the pan applies to the left portion of the screen. Here's how I do this by implementing one of `UIGestureRecognizer` delegate methods:

``` objective-c
-(BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
    if ([gestureRecognizer locationInView:gestureRecognizer.view].x < 70.0) {
        return YES;
    }
    return NO;
}
```
