### PR TITLE
Increase menu frame width during bounce

### DIFF
--- a/lib/NVSlideMenuController/NVSlideMenuController.m
+++ b/lib/NVSlideMenuController/NVSlideMenuController.m
@@ -596,8 +596,12 @@
         CGRect contentBounceFrame = contentView.frame;
         contentBounceFrame.origin.x += bounceDistance;
         
+        CGRect menuBounceFrame = [[self.menuViewController view] frame];
+        menuBounceFrame.size.width += bounceDistance;
+
         [UIView animateWithDuration:BOUNCE_DURATION delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
             contentView.frame = contentBounceFrame;
+            self.menuViewController.view.frame = menuBounceFrame;
         } completion:^(BOOL finished) {
             if (swapContentViewController)
 				swapContentViewController();


### PR DESCRIPTION
Hi, not sure if this repo is still being maintained/used and/or this is something you'd be interested in.. but this is a fix I made a while back.

The issue is this:
- You open the menu
- You select an item
- The content view bounces to the right
- The background, that is, where the content view used to be, doesn't match the menu.

The solution is to extend the menu frame during the bounce, which looks nice and certainly way better than no fix at all.
